### PR TITLE
Explicit count modifiers

### DIFF
--- a/ats.tmLanguage
+++ b/ats.tmLanguage
@@ -98,7 +98,7 @@
 		<key>char</key>
 		<dict>
 			<key>match</key>
-			<string>(')([^\\]{,1}|\\(\\|[abefpnrtv'"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8}))(')</string>
+			<string>(')([^\\]{0,1}|\\(\\|[abefpnrtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8}))(')</string>
 			<key>name</key>
 			<string>string.quoted.double</string>
 		</dict>
@@ -242,7 +242,7 @@
 		<key>string_escaped</key>
 		<dict>
 			<key>match</key>
-			<string>\\(\\|[abefnprtv'"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})</string>
+			<string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})</string>
 			<key>name</key>
 			<string>constant.character.escape</string>
 		</dict>


### PR DESCRIPTION
The construction `{,2}` in regular expressions is only supported by Oniguruma (which is used by Sublime Text). This package is used to highlight ATS code on GitHub. However, GitHub is using a [PCRE-based engine](https://github.com/vmg/pcre) for regexes and thus, the following code gets incorrectly highlighted.
```ats
#define ATS_PACKNAME '\00'
```

This pull request fixes that by using an explicit count modifier in regular expressions.